### PR TITLE
Fix for MarkupProps properties update logic

### DIFF
--- a/markuptotexttag/properties.py
+++ b/markuptotexttag/properties.py
@@ -50,6 +50,7 @@ class MarkupProps(object):
 		for prop in self.properties:
 			if prop['start'] == start and prop['end'] == end:
 				prop['properties'].update({label:value})
+                                break
 		else:
 			new_prop = 	{
 							'properties': {label:value},


### PR DESCRIPTION
Adding just a tiny fix to for-loop of add() method in MarkupProps. Without a break in for-loop the else will be executed always upon iteration completion (meaning, even if the property was found and updated, a new one will be created regardless). 
Thank you for sharing your module (useful and spares time)!